### PR TITLE
Return true if string is falsey, otherwise true if non-empty

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -230,7 +230,7 @@ type swaggerInfo struct {
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = swaggerInfo{
-	Version:     "0.2.11",
+	Version:     "0.2.12",
 	Host:        "",
 	BasePath:    "",
 	Schemes:     []string{},

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -11,7 +11,7 @@
             "name": "MIT",
             "url": "https://github.com/circa10a/k8s-label-rules-webhook/blob/master/LICENSE"
         },
-        "version": "0.2.11"
+        "version": "0.2.12"
     },
     "paths": {
         "//": {

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -78,7 +78,7 @@ info:
     name: MIT
     url: https://github.com/circa10a/k8s-label-rules-webhook/blob/master/LICENSE
   title: k8s-label-rules-webhook
-  version: 0.2.11
+  version: 0.2.12
 paths:
   //:
     post:

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func flags() {
 }
 
 // @title k8s-label-rules-webhook
-// @version 0.2.11
+// @version 0.2.12
 // @description A kubernetes webhook to standardize labels on resources
 
 // @contact.name GitHub

--- a/utils.go
+++ b/utils.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io/ioutil"
 	"os"
+	"strconv"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -16,6 +17,9 @@ func readFile(path string) ([]byte, error) {
 }
 
 func str2bool(s string) bool {
+	if b, err := strconv.ParseBool(s); err == nil {
+		return b
+	}
 	return s != ""
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -17,6 +17,7 @@ func TestReadFile(t *testing.T) {
 func TestStr2Bool(t *testing.T) {
 	t.Parallel()
 	assert.True(t, str2bool("test"), "Converts nonempty string to true")
+	assert.False(t, str2bool("false"), "Converts false string to false")
 	assert.False(t, str2bool(""), "Converts empty string to false")
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -17,6 +17,7 @@ func TestReadFile(t *testing.T) {
 func TestStr2Bool(t *testing.T) {
 	t.Parallel()
 	assert.True(t, str2bool("test"), "Converts nonempty string to true")
+	assert.True(t, str2bool("true"), "Converts true string to true")
 	assert.False(t, str2bool("false"), "Converts false string to false")
 	assert.False(t, str2bool(""), "Converts empty string to false")
 }


### PR DESCRIPTION
This fixes #41 while keeping the original logic of an otherwise non-empty string returning true.